### PR TITLE
do not show missing argument to realpath

### DIFF
--- a/functions/mou.fish
+++ b/functions/mou.fish
@@ -1,5 +1,5 @@
 function mou -d "The missing Markdown editor for web developers"
-  if set -l path (realpath $argv)
+  if set -l path (realpath $argv 2> /dev/null)
     echo "tell application \"Mou\"
             open \"$path\"
             activate


### PR DESCRIPTION
When I do not pass an argument to `mou` I get the following output:

```
realpath: missing operand
Try 'realpath --help' for more information.
```

With the `2> /dev/null` you just ignore that stderr output.
