### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/mou.fish
+++ b/functions/mou.fish
@@ -3,8 +3,8 @@ function mou -d "The missing Markdown editor for web developers"
     echo "tell application \"Mou\"
             open \"$path\"
             activate
-          end tell" | osascript >/dev/null ^&1
+          end tell" | osascript >/dev/null 2>&1
   else
-    echo "tell application \"Mou\" to activate" | osascript >/dev/null ^&1
+    echo "tell application \"Mou\" to activate" | osascript >/dev/null 2>&1
   end
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618